### PR TITLE
Nullable fields to create Users from an Ldap Server

### DIFF
--- a/Resources/config/doctrine/User.orm.yml
+++ b/Resources/config/doctrine/User.orm.yml
@@ -13,12 +13,15 @@ Egzakt\SystemBundle\Entity\User:
     firstname:
       type: string
       length: 255
+      nullable: true
     lastname:
       type: string
       length: 255
+      nullable: true
     email:
       type: string
       length: 255
+      nullable: true
     facebookId:
       type: string
       length: 255
@@ -31,6 +34,7 @@ Egzakt\SystemBundle\Entity\User:
     salt:
       type: string
       length: 32
+      nullable: true
     createdAt:
       type: datetime
       gedmo:


### PR DESCRIPTION
When creating a new User from an Ldap Server, we only have the username/password/active informations. All other fields should be nullable.
