### PR TITLE
Automatically disable JMSi18nRouting support based on the application of a route

### DIFF
--- a/DependencyInjection/Compiler/RouterExtensionCompilerPass.php
+++ b/DependencyInjection/Compiler/RouterExtensionCompilerPass.php
@@ -20,6 +20,7 @@ class RouterExtensionCompilerPass implements CompilerPassInterface
 
         // i18n loader override
         $container->setParameter('jms_i18n_routing.loader.class', 'Egzakt\\SystemBundle\\Routing\\Loader');
+        $container->setParameter('jms_i18n_routing.route_exclusion_strategy.class', 'Egzakt\\SystemBundle\\Routing\\RouteExclusionStrategy');
         $container->findDefinition('jms_i18n_routing.loader')->addMethodCall('setDatabaseConnection', array(
             new Reference('database_connection')
         ));

--- a/Routing/RouteExclusionStrategy.php
+++ b/Routing/RouteExclusionStrategy.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Egzakt\SystemBundle\Routing;
+
+use Symfony\Component\Routing\Route;
+
+use JMS\I18nRoutingBundle\Router\DefaultRouteExclusionStrategy;
+
+/**
+ * The egzakt route exclusion strategy.
+ *
+ * This strategy add one condition to the default JMSi18nRouting excludes list:
+ *
+ *     - the route must not be from a egzakt backend application
+ */
+class RouteExclusionStrategy extends DefaultRouteExclusionStrategy
+{
+    public function shouldExcludeRoute($routeName, Route $route)
+    {
+        $shouldExclude = parent::shouldExcludeRoute($routeName, $route);
+
+        if ($shouldExclude) {
+            return true;
+        }
+
+        // automatically exclude if the route is a egzakt backend one
+        if (preg_match('/egzakt_[a-zA-Z0-9-_]*backend_/', $routeName)) {
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
This PR improve the way of including routes in the app/routing.yml file. The i18n option is no longer required and is automatically guessed based on the application of the route.

before: 

``` yml
egzakt_system_backend:
    resource: "@EgzaktSystemBundle/Resources/config/routing_backend.yml"
    prefix:   /admin
    options:
      i18n: false

egzakt_system_frontend:
    resource: "@EgzaktSystemBundle/Resources/config/routing_frontend.yml"
    options:
      i18n: true
```

after:

``` yml
egzakt_system_backend:
    resource: "@EgzaktSystemBundle/Resources/config/routing_backend.yml"
    prefix:   /admin

egzakt_system_frontend:
    resource: "@EgzaktSystemBundle/Resources/config/routing_frontend.yml"
```
