### PR TITLE
Use ArrayCollection in Breadcrumbs instead of array()

### DIFF
--- a/Lib/Breadcrumbs.php
+++ b/Lib/Breadcrumbs.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Egzakt\SystemBundle\Lib;
+
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**


### PR DESCRIPTION
More oriented-object code using ArrayCollection ( no more loop for deleting an element )
