### PR TITLE
Bug if $this->errors is not initialized

### DIFF
--- a/Lib/BaseDeletableListener.php
+++ b/Lib/BaseDeletableListener.php
@@ -38,6 +38,9 @@ abstract class BaseDeletableListener implements DeletableListenerInterface
      */
     public function getErrors()
     {
+        if (null === $this->errors) {
+            $this->errors = new ArrayCollection();
+        }
         return $this->errors;
     }
 


### PR DESCRIPTION
When validated is called, $this->getErrors() might return null and thus, calling isEmpty() on something null throw an exception !
