### PR TITLE
Extractor ignores Backend templates

### DIFF
--- a/Controller/Backend/Translation/TranslationController.php
+++ b/Controller/Backend/Translation/TranslationController.php
@@ -90,10 +90,7 @@ class TranslationController extends BaseController
                 $templateCatalogue = new MessageCatalogue($locale->getCode());
 
                 // Custom Template Extractor
-                // TODO: Create a service and a CompilerPass to add the extractors
-                $extractor = new ChainExtractor();
-                $extractor->addExtractor('twig', new TwigExtractor($this->container->get('twig')));
-                $extractor->addExtractor('php', new PhpExtractor());
+                $extractor = $this->container->get('flexy_system.translation.extractor');
                 file_exists($bundleViewPath) ? $extractor->extract($bundleViewPath, $templateCatalogue) : null;
 
                 // load any existing messages from the translation files

--- a/Controller/Backend/Translation/TranslationController.php
+++ b/Controller/Backend/Translation/TranslationController.php
@@ -2,8 +2,8 @@
 
 namespace Flexy\SystemBundle\Controller\Backend\Translation;
 
-use Flexy\SystemBundle\Translation\Php\PhpExtractor;
-use Flexy\SystemBundle\Translation\Twig\TwigExtractor;
+use Flexy\SystemBundle\Translation\Extractor\PhpExtractor;
+use Flexy\SystemBundle\Translation\Extractor\TwigExtractor;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;

--- a/Controller/Backend/Translation/TranslationController.php
+++ b/Controller/Backend/Translation/TranslationController.php
@@ -2,12 +2,15 @@
 
 namespace Flexy\SystemBundle\Controller\Backend\Translation;
 
+use Flexy\SystemBundle\Translation\Php\PhpExtractor;
+use Flexy\SystemBundle\Translation\Twig\TwigExtractor;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Translation\Extractor\ChainExtractor;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\Catalogue\MergeOperation;
 
@@ -85,7 +88,12 @@ class TranslationController extends BaseController
                 // load any messages from templates
                 $bundleViewPath = $bundle->getPath() . '/Resources/views/';
                 $templateCatalogue = new MessageCatalogue($locale->getCode());
-                $extractor = $this->container->get('translation.extractor');
+
+                // Custom Template Extractor
+                // TODO: Create a service and a CompilerPass to add the extractors
+                $extractor = new ChainExtractor();
+                $extractor->addExtractor('twig', new TwigExtractor($this->container->get('twig')));
+                $extractor->addExtractor('php', new PhpExtractor());
                 file_exists($bundleViewPath) ? $extractor->extract($bundleViewPath, $templateCatalogue) : null;
 
                 // load any existing messages from the translation files

--- a/DependencyInjection/Compiler/TranslationExtractorPass.php
+++ b/DependencyInjection/Compiler/TranslationExtractorPass.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flexy\SystemBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * Adds tagged translation.extractor services to translation extractor
+ */
+class TranslationExtractorPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('translation.extractor')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('flexy_system.translation.extractor');
+
+        foreach ($container->findTaggedServiceIds('flexy_system.translation.extractor') as $id => $attributes) {
+            if (!isset($attributes[0]['alias'])) {
+                throw new \RuntimeException(sprintf('The alias for the tag "translation.extractor" of service "%s" must be set.', $id));
+            }
+
+            $definition->addMethodCall('addExtractor', array($attributes[0]['alias'], new Reference($id)));
+        }
+    }
+}

--- a/FlexySystemBundle.php
+++ b/FlexySystemBundle.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use Flexy\SystemBundle\DependencyInjection\Compiler\RouterExtensionCompilerPass;
 use Flexy\SystemBundle\DependencyInjection\Compiler\HttpKernelExtensionCompilerPass;
+use Flexy\SystemBundle\DependencyInjection\Compiler\TranslationExtractorPass;
 
 class FlexySystemBundle extends Bundle
 {
@@ -16,5 +17,6 @@ class FlexySystemBundle extends Bundle
         $container->addCompilerPass(new RouterExtensionCompilerPass());
         $container->addCompilerPass(new HttpKernelExtensionCompilerPass());
         $container->addCompilerPass(new DeletableExtensionCompilerPass());
+        $container->addCompilerPass(new TranslationExtractorPass());
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -31,6 +31,9 @@ parameters:
     flexy_backend.login_listener.class:                        Flexy\SystemBundle\Listener\LoginBackendListener
     flexy_frontend.core.class:                                 Flexy\SystemBundle\Lib\Frontend\Core
     flexy_system.translation_editor_loader.class:              Flexy\SystemBundle\Translation\TranslationEditorLoader
+    flexy_system.translation.extractor.class:                  Symfony\Component\Translation\Extractor\ChainExtractor
+    flexy_system.translation.extractor.php.class:              Flexy\SystemBundle\Translation\Extractor\PhpExtractor
+    flexy_system.translation.extractor.twig.class:             Flexy\SystemBundle\Translation\Extractor\TwigExtractor
 
 services:
 
@@ -200,7 +203,7 @@ services:
 
     flexy_system.security.cms_voter:
         class: %flexy_backend.security.cms_voter.class%
-        arguments: [@service_container]
+        arguments: [ @service_container ]
         tags:
             - { name: security.voter }
 
@@ -211,6 +214,20 @@ services:
 
     flexy_system.translation.translator_editor_loader:
         class: %flexy_system.translation_editor_loader.class%
-        arguments: [@doctrine.orm.entity_manager, %kernel.root_dir%]
+        arguments: [ @doctrine.orm.entity_manager, %kernel.root_dir% ]
         tags:
             - { name: translation.loader, alias: db }
+
+    flexy_system.translation.extractor:
+        class: %flexy_system.translation.extractor.class%
+
+    flexy_system.translation.extractor.php:
+        class: %flexy_system.translation.extractor.php.class%
+        tags:
+            - { name: flexy_system.translation.extractor, alias: php }
+
+    flexy_system.translation.extractor.twig:
+        class: %flexy_system.translation.extractor.twig.class%
+        arguments: [ @twig ]
+        tags:
+            - { name: flexy_system.translation.extractor, alias: twig }

--- a/Resources/public/backend/css/main.css
+++ b/Resources/public/backend/css/main.css
@@ -1590,6 +1590,13 @@ span.cke_skin_kama {
 
 /* MESSAGES
 -----------------------------------------*/
+.flash-success.popup,
+.flash-error.popup {
+    top: 50%;
+    left: 50%;
+    position: fixed;
+}
+
 .flash-success {
     font-weight: bold;
     margin: 5px 0;

--- a/Resources/views/Backend/Translation/Translation/list.html.twig
+++ b/Resources/views/Backend/Translation/Translation/list.html.twig
@@ -128,13 +128,9 @@
             if (data.success) {
 
                 var success_message = $('<div/>', {
-                    'class': 'flash-success',
+                    'class': 'flash-success popup',
                     'text': data.message
                 });
-
-                success_message.css('top', '50%');
-                success_message.css('left', '50%');
-                success_message.css('position', 'fixed');
 
                 $(success_message).insertAfter($('body'));
 

--- a/Translation/Extractor/PhpExtractor.php
+++ b/Translation/Extractor/PhpExtractor.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flexy\SystemBundle\Translation\Extractor;
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Bundle\FrameworkBundle\Translation\PhpExtractor as BasePhpExtractor;
+
+/**
+ * PhpExtractor extracts translation messages from a php template.
+ *
+ * @author Michel Salib <michelsalib@hotmail.com>
+ */
+class PhpExtractor extends BasePhpExtractor
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function extract($directory, MessageCatalogue $catalog)
+    {
+        // load any existing translation files
+        $finder = new Finder();
+        $files = $finder->files()->name('*.php')->in($directory);
+        foreach ($files as $file) {
+            // Ignore Backend Templates
+            if (strpos($file->getPathname(), '/Backend/') === false) {
+                $this->parseTokens(token_get_all(file_get_contents($file)), $catalog);
+            }
+        }
+    }
+
+}

--- a/Translation/Extractor/TwigExtractor.php
+++ b/Translation/Extractor/TwigExtractor.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flexy\SystemBundle\Translation\Extractor;
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Bridge\Twig\Translation\TwigExtractor as BaseTwigExtractor;
+
+/**
+ * TwigExtractor extracts translation messages from a twig template.
+ *
+ * @author Michel Salib <michelsalib@hotmail.com>
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class TwigExtractor extends BaseTwigExtractor
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function extract($directory, MessageCatalogue $catalogue)
+    {
+        // load any existing translation files
+        $finder = new Finder();
+        $files = $finder->files()->name('*.twig')->in($directory);
+        foreach ($files as $file) {
+            // Ignore Backend Templates
+            if (strpos($file->getPathname(), '/Backend/') === false) {
+                $this->extractTemplate(file_get_contents($file->getPathname()), $catalogue);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Twig and Php extractors ignore the Backend template when you build the Translation Tokens

I also moved the CSS for the success message into the main.css