### PR TITLE
Error pages handling to work with the Unifik requests

### DIFF
--- a/Listener/ExceptionListener.php
+++ b/Listener/ExceptionListener.php
@@ -2,12 +2,19 @@
 
 namespace Unifik\SystemBundle\Listener;
 
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+use Symfony\Component\Translation\Translator;
 use Symfony\Bundle\TwigBundle\Debug\TimedTwigEngine;
-use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Kernel;
+
+use Unifik\SystemBundle\Entity\Section;
+use Unifik\SystemBundle\Lib\Frontend\Core;
 
 /**
  * Exception Listener
@@ -25,6 +32,31 @@ class ExceptionListener
     private $templating;
 
     /**
+     * @var Translator
+     */
+    private $translator;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var EntityManager;
+     */
+    private $entityManager;
+
+    /**
+     * @var Core
+     */
+    private $core;
+
+    /**
+     * @var string
+     */
+    private $defaultLocale;
+
+    /**
      * Event handler that renders custom pages in case of a NotFoundHttpException (404)
      * or a AccessDeniedHttpException (403).
      *
@@ -38,7 +70,16 @@ class ExceptionListener
 
         $exception = $event->getException();
 
+        $this->request->setLocale($this->defaultLocale);
+
         if ($exception instanceof NotFoundHttpException) {
+
+            $section = $this->getExceptionSection(404, '404 Error');
+
+            $this->core->addNavigationElement($section);
+
+            $unifikRequest = $this->generateUnifikRequest($section);
+            $this->setUnifikRequestAttributes($unifikRequest);
 
             $response = $this->templating->renderResponse('UnifikSystemBundle:Frontend/Exception:404.html.twig');
             $response->setStatusCode(404);
@@ -47,11 +88,87 @@ class ExceptionListener
 
         } elseif ($exception instanceof AccessDeniedHttpException) {
 
+            $section = $this->getExceptionSection(403, '403 Error');
+
+            $this->core->addNavigationElement($section);
+
+            $unifikRequest = $this->generateUnifikRequest($section);
+            $this->setUnifikRequestAttributes($unifikRequest);
+
             $response = $this->templating->renderResponse('UnifikSystemBundle:Frontend/Exception:403.html.twig');
             $response->setStatusCode(403);
 
             $event->setResponse($response);
         }
+    }
+
+    /**
+     * Generates a Unifik Request
+     *
+     * @param Section $section
+     * @return array
+     */
+    private function generateUnifikRequest(Section $section)
+    {
+        // TODO: Fetch the right App from the database
+        $unifikRequest = array(
+            'sectionId' => $section->getId(),
+            'appId' => 2, // Frontend
+            'appPrefix' => '',
+            'appName' => 'Frontend',
+            'appSlug' => ''
+        );
+
+        return $unifikRequest;
+    }
+
+    /**
+     * Set the Unifik Request attributes in the Request
+     *
+     * @param $unifikRequest
+     */
+    private function setUnifikRequestAttributes($unifikRequest)
+    {
+        $this->request->attributes->set('_unifikEnabled', true);
+        $this->request->attributes->set('_unifikRequest', $unifikRequest);
+    }
+
+    /**
+     * Return the specific Section for an Exception Event
+     *
+     * @param $id
+     * @param $name
+     *
+     * @return object|Section
+     */
+    private function getExceptionSection($id, $name)
+    {
+        // TODO Use a tagging system with internal tags. ie: _section_404
+        $sectionRepository = $this->entityManager->getRepository('UnifikSystemBundle:Section');
+        $sectionRepository->setCurrentAppName('frontend');
+        $sectionRepository->setLocale($this->defaultLocale);
+
+        $section = $sectionRepository->find($id);
+
+        // Doesn't exist, create the Section
+        if (!$section) {
+            $section = new Section();
+            $section->setCurrentLocale($this->defaultLocale);
+            $section->setApp($this->entityManager->getRepository('UnifikSystemBundle:App')->find(2));
+            $section->setId($id);
+            $section->setName($this->translator->trans($name, array(), 'messages', $this->defaultLocale));
+            $section->setActive(true);
+
+            $this->entityManager->persist($section);
+
+            // Force ID
+            $metadata = $this->entityManager->getClassMetaData(get_class($section));
+            $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
+
+            $this->entityManager->flush();
+        }
+
+        return $section;
     }
 
     /**
@@ -68,5 +185,45 @@ class ExceptionListener
     public function setTemplating($templating)
     {
         $this->templating = $templating;
+    }
+
+    /**
+     * @param Request|null $request
+     */
+    public function setRequest($request = null)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * @param Translator $translator
+     */
+    public function setTranslator($translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * @param string $defaultLocale
+     */
+    public function setDefaultLocale($defaultLocale)
+    {
+        $this->defaultLocale = $defaultLocale;
+    }
+
+    /**
+     * @param EntityManager $entityManager
+     */
+    public function setEntityManager($entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * @param \Unifik\SystemBundle\Lib\Frontend\Core $core
+     */
+    public function setCore($core)
+    {
+        $this->core = $core;
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -80,6 +80,11 @@ services:
         calls:
             - [ setKernel, [ @kernel ] ]
             - [ setTemplating, [ @templating ] ]
+            - [ setTranslator, [ @translator ] ]
+            - [ setEntityManager, [ @doctrine.orm.default_entity_manager] ]
+            - [ setRequest, [ @?request= ] ]
+            - [ setCore, [ @unifik_frontend.core ] ]
+            - [ setDefaultLocale, [%locale%] ]
 
     unifik_system.core:
         class: %unifik_system.core.class%

--- a/Resources/translations/messages.fr.yml
+++ b/Resources/translations/messages.fr.yml
@@ -145,3 +145,8 @@ Home page URL: URL de la page d'accueil
 Home: Accueil
 ":": " :"
 
+404 Error: Erreur 404
+404 Not Found: Erreur 404
+The requested URL was not found on this server: La page à laquelle vous tentez d'accéder n'existe pas ou a été déplacée
+403 Error: Erreur 403
+403 Forbidden - Access Denied: Erreur 403 - Accès non-autorisé

--- a/Resources/views/Frontend/Exception/404.html.twig
+++ b/Resources/views/Frontend/Exception/404.html.twig
@@ -1,5 +1,5 @@
 {% extends 'UnifikSystemBundle:Frontend:layout.html.twig' %}
 
 {% block content %}
-    {% trans %}404 Not found{% endtrans %}
+    {% trans %}404 Not Found{% endtrans %} : {% trans %}The requested URL was not found on this server{% endtrans %}.
 {% endblock %}


### PR DESCRIPTION
This is a "temporary" fix for the error pages.

Specific Section objects are used to display 403/404 error pages. This way, everything is compatible with the Unifik Request system.
